### PR TITLE
add ranges to gic definition to enable GIC-ITS.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
@@ -1591,6 +1591,7 @@
 
 	gic: interrupt-controller@fe600000 {
 		compatible = "arm,gic-v3";
+		ranges;
 		reg = <0x0 0xfe600000 0 0x10000>, /* GICD */
 		      <0x0 0xfe680000 0 0x100000>; /* GICR */
 		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH 0>;


### PR DESCRIPTION
of_translate_address fails to successfully lookup and translate the GIC-ITS addresses. I don't know if this is some new requirement for the newer kernels or what but it works with this addition.